### PR TITLE
Simple Helm Chart and documentation fixes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.1.0"
+version: "0.1.1"
 
 # The latest version of Openshift tested is 4.11. This corresponds to KubeVersion 1.24. KubeVersion supported by Openshift 4.11 is 1.24.
 # It could work on earlier versions but remains untested and unsupported

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ If you are not on the default, please use the command\
 
 2. Install the helm chart
 From the folder , \
+    `cd zpa-openshift`
     `helm install [NAME] [CHART] [flags]` \
-    `helm install [NAME] --set zsglobal.provisionkey.value="<provision_key>"  zpa-app-connector-openshift-0.1.0.tgz` \
+    `helm install [NAME] --set zsglobal.provisionkey.value="<provision_key>" .` \
      You can retrieve the provisioning key from the [ZPA Admin Portal](https://admin.private.zscaler.com/). To learn more, see [About App Connector Provisioning Keys](https://help.zscaler.com/zpa/about-connector-provisioning-keys).
 
 <br/><br/>

--- a/templates/securitycontextconstraints.yaml
+++ b/templates/securitycontextconstraints.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.zsglobal.securityContextConstraints.create }}
 {{- if not .Values.zsglobal.multiConnector.enabled }}
 kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
@@ -22,4 +23,5 @@ allowHostPID: false
 allowHostPorts: false
 allowPrivilegedContainer: false
 readOnlyRootFilesystem: false
- {{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Fixed the following:
- README.md pointing to a tgz file instead of a folder based chart
- .Values.zsglobal.securityContextConstraints.create not taken into account
- Incremented the Helm Chart version
- In templates/securitycontextconstraints.yaml last line `{{- end }}` being in the wrong level of indentation

